### PR TITLE
perf(text_rank): remove extensive use of String in favour of &str instead

### DIFF
--- a/src/rake/rake_logic.rs
+++ b/src/rake/rake_logic.rs
@@ -112,7 +112,7 @@ impl RakeLogic {
         phrases
             .par_iter()
             .fold(
-                || HashMap::<&str, f32>::new(),
+                HashMap::<&str, f32>::new,
                 |mut acc, phrase| {
                     phrase.iter().for_each(|word| {
                         *acc.entry(word).or_insert(0.0) += 1.0;
@@ -121,7 +121,7 @@ impl RakeLogic {
                 },
             )
             .reduce(
-                || HashMap::<&str, f32>::new(),
+                HashMap::<&str, f32>::new,
                 |mut acc, hmap| {
                     hmap.iter().for_each(|(word, count)| {
                         *acc.entry(word).or_insert(0.0) += count;
@@ -162,7 +162,7 @@ impl RakeLogic {
         phrases
             .par_iter()
             .fold(
-                || HashMap::<&str, f32>::new(),
+                HashMap::<&str, f32>::new,
                 |mut acc, phrase| {
                     let len = phrase.len() as f32 - 1.0;
                     phrase.iter().for_each(|word| {
@@ -174,7 +174,7 @@ impl RakeLogic {
                 },
             )
             .reduce(
-                || HashMap::<&str, f32>::new(),
+                HashMap::<&str, f32>::new,
                 |mut acc, hmap| {
                     hmap.iter().for_each(|(word, degree)| {
                         *acc.entry(word).or_insert(0.0) += degree;

--- a/src/text_rank/text_rank_logic.rs
+++ b/src/text_rank/text_rank_logic.rs
@@ -155,8 +155,6 @@ impl TextRankLogic {
     }
 
     fn create_graph(words: &[String], window_size: usize) -> HashMap<&str, HashMap<&str, f32>> {
-        let mut graph = HashMap::new();
-
         words
             .iter()
             .enumerate()
@@ -167,12 +165,11 @@ impl TextRankLogic {
                     .filter(|word2| word1.as_str() != word2.as_str())
                     .map(move |word2| (word1, word2))
             })
-            .for_each(|(word1, word2)| {
+            .fold(HashMap::new(), |mut graph, (word1, word2)| {
                 Self::add_edge(&mut graph, word1, word2);
                 Self::add_edge(&mut graph, word2, word1);
-            });
-
-        graph
+                graph
+            })
     }
 
     fn get_outgoing_weight_sum<'a>(

--- a/src/text_rank/text_rank_logic.rs
+++ b/src/text_rank/text_rank_logic.rs
@@ -31,9 +31,9 @@ fn score_phrase(phrase: &str, word_rank: &HashMap<String, f32>) -> (String, f32)
 }
 
 fn score_word(
-    edges: &HashMap<String, f32>,
-    node_indexes: &HashMap<String, usize>,
-    outgoing_weight_sums: &HashMap<String, f32>,
+    edges: &HashMap<&str, f32>,
+    node_indexes: &HashMap<&str, usize>,
+    outgoing_weight_sums: &HashMap<&str, f32>,
     prev_scores: &[f32],
     damping: f32,
 ) -> f32 {
@@ -49,13 +49,13 @@ fn score_word(
     (1.0 - damping) + damping * new_score
 }
 
-fn get_node_indexes(nodes: &[&String]) -> HashMap<String, usize> {
+fn get_node_indexes<'a>(nodes: &'a [&'a str]) -> HashMap<&'a str, usize> {
     #[cfg(feature = "parallel")]
     {
         nodes
             .par_iter()
             .enumerate()
-            .map(|(i, w)| (w.to_string(), i))
+            .map(|(i, w)| (*w, i))
             .collect::<HashMap<String, usize>>()
     }
 
@@ -64,15 +64,15 @@ fn get_node_indexes(nodes: &[&String]) -> HashMap<String, usize> {
         nodes
             .iter()
             .enumerate()
-            .map(|(i, w)| (w.to_string(), i))
-            .collect::<HashMap<String, usize>>()
+            .map(|(i, w)| (*w, i))
+            .collect::<HashMap<&str, usize>>()
     }
 }
 
 fn get_scores(
-    graph: &HashMap<String, HashMap<String, f32>>,
-    node_indexes: &HashMap<String, usize>,
-    outgoing_weight_sums: &HashMap<String, f32>,
+    graph: &HashMap<&str, HashMap<&str, f32>>,
+    node_indexes: &HashMap<&str, usize>,
+    outgoing_weight_sums: &HashMap<&str, f32>,
     prev_scores: &[f32],
     damping: f32,
 ) -> Vec<f32> {
@@ -136,24 +136,28 @@ impl TextRankLogic {
         tol: f32,
     ) -> (HashMap<String, f32>, HashMap<String, f32>) {
         let word_rank =
-            Self::create_word_rank(Self::create_graph(words, window_size), damping, tol);
+            Self::create_word_rank(Self::create_graph(&words, window_size), damping, tol);
         let phrase_rank = Self::rank_phrases(phrases, &word_rank);
         (word_rank, phrase_rank)
     }
 
-    fn add_edge(graph: &mut HashMap<String, HashMap<String, f32>>, word1: &str, word2: &str) {
+    fn add_edge<'a>(
+        graph: &mut HashMap<&'a str, HashMap<&'a str, f32>>,
+        word1: &'a str,
+        word2: &'a str,
+    ) {
         graph
-            .entry(word1.to_string())
+            .entry(word1)
             .or_insert_with(HashMap::new)
-            .entry(word2.to_string())
+            .entry(word2)
             .and_modify(|e| *e += 1.0)
             .or_insert(1.0);
     }
 
-    fn create_graph(
-        words: Vec<String>,
+    fn create_graph<'a>(
+        words: &'a [String],
         window_size: usize,
-    ) -> HashMap<String, HashMap<String, f32>> {
+    ) -> HashMap<&'a str, HashMap<&'a str, f32>> {
         let mut graph = HashMap::new();
 
         words
@@ -174,16 +178,16 @@ impl TextRankLogic {
         graph
     }
 
-    fn get_outgoing_weight_sum(
-        graph: &HashMap<String, HashMap<String, f32>>,
-    ) -> HashMap<String, f32> {
+    fn get_outgoing_weight_sum<'a>(
+        graph: &'a HashMap<&'a str, HashMap<&'a str, f32>>,
+    ) -> HashMap<&'a str, f32> {
         #[cfg(feature = "parallel")]
         {
             graph
                 .par_iter()
                 .map(|(node, edges)| {
                     let outgoing_weight_sum = edges.values().sum();
-                    (node.to_string(), outgoing_weight_sum)
+                    (*node, outgoing_weight_sum)
                 })
                 .collect()
         }
@@ -194,18 +198,18 @@ impl TextRankLogic {
                 .iter()
                 .map(|(node, edges)| {
                     let outgoing_weight_sum = edges.values().sum();
-                    (node.to_string(), outgoing_weight_sum)
+                    (*node, outgoing_weight_sum)
                 })
                 .collect()
         }
     }
 
-    fn create_word_rank(
-        graph: HashMap<String, HashMap<String, f32>>,
+    fn create_word_rank<'a>(
+        graph: HashMap<&'a str, HashMap<&'a str, f32>>,
         damping: f32,
         tol: f32,
     ) -> HashMap<String, f32> {
-        let nodes = graph.keys().collect::<Vec<&String>>();
+        let nodes = graph.keys().into_iter().map(|v| *v).collect::<Vec<&str>>();
         let n = nodes.len();
         let node_indexes = get_node_indexes(&nodes);
         let mut scores = vec![1.0_f32; n];

--- a/src/text_rank/text_rank_logic.rs
+++ b/src/text_rank/text_rank_logic.rs
@@ -83,9 +83,9 @@ fn get_scores(
             .map(|(_, edges)| {
                 score_word(
                     edges,
-                    &node_indexes,
-                    &outgoing_weight_sums,
-                    &prev_scores,
+                    node_indexes,
+                    outgoing_weight_sums,
+                    prev_scores,
                     damping,
                 )
             })
@@ -99,9 +99,9 @@ fn get_scores(
             .map(|edges| {
                 score_word(
                     edges,
-                    &node_indexes,
-                    &outgoing_weight_sums,
-                    &prev_scores,
+                    node_indexes,
+                    outgoing_weight_sums,
+                    prev_scores,
                     damping,
                 )
             })
@@ -148,16 +148,13 @@ impl TextRankLogic {
     ) {
         graph
             .entry(word1)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(word2)
             .and_modify(|e| *e += 1.0)
             .or_insert(1.0);
     }
 
-    fn create_graph<'a>(
-        words: &'a [String],
-        window_size: usize,
-    ) -> HashMap<&'a str, HashMap<&'a str, f32>> {
+    fn create_graph(words: &[String], window_size: usize) -> HashMap<&str, HashMap<&str, f32>> {
         let mut graph = HashMap::new();
 
         words
@@ -209,7 +206,7 @@ impl TextRankLogic {
         damping: f32,
         tol: f32,
     ) -> HashMap<String, f32> {
-        let nodes = graph.keys().into_iter().map(|v| *v).collect::<Vec<&str>>();
+        let nodes = graph.keys().copied().collect::<Vec<&str>>();
         let n = nodes.len();
         let node_indexes = get_node_indexes(&nodes);
         let mut scores = vec![1.0_f32; n];

--- a/src/text_rank/text_rank_logic.rs
+++ b/src/text_rank/text_rank_logic.rs
@@ -56,7 +56,7 @@ fn get_node_indexes<'a>(nodes: &'a [&'a str]) -> HashMap<&'a str, usize> {
             .par_iter()
             .enumerate()
             .map(|(i, w)| (*w, i))
-            .collect::<HashMap<String, usize>>()
+            .collect::<HashMap<&str, usize>>()
     }
 
     #[cfg(not(feature = "parallel"))]

--- a/src/tf_idf/tf_idf_logic.rs
+++ b/src/tf_idf/tf_idf_logic.rs
@@ -60,7 +60,7 @@ impl TfIdfLogic {
         documents
             .par_iter()
             .fold(
-                || HashMap::new(),
+                HashMap::new,
                 |mut acc, document| {
                     document
                         .split_whitespace()
@@ -69,7 +69,7 @@ impl TfIdfLogic {
                 },
             )
             .reduce(
-                || HashMap::new(),
+                HashMap::new,
                 |mut acc, hmap| {
                     for (word, count) in hmap {
                         *acc.entry(word).or_insert(0.0) += count;
@@ -110,7 +110,7 @@ impl TfIdfLogic {
             .par_iter()
             .map(|document| document.split_whitespace().collect::<HashSet<&str>>())
             .fold(
-                || HashMap::new(),
+                HashMap::new,
                 |mut acc, unique_words| {
                     unique_words
                         .into_iter()
@@ -119,7 +119,7 @@ impl TfIdfLogic {
                 },
             )
             .reduce(
-                || HashMap::new(),
+                HashMap::new,
                 |mut acc, hmap| {
                     for (word, count) in hmap {
                         *acc.entry(word).or_insert(0.0) += count;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -267,7 +267,7 @@ impl Tokenizer {
                             phrases,
                             acc,
                             w,
-                            &special_char_regex,
+                            special_char_regex,
                             &self.punctuation,
                             &self.stopwords,
                             length,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
  guidelines: https://github.com/tugascript/keyword-extraction-rs/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Other... Please describe:

## What is the current behavior?

Heavy use of `String` and heap memory for `text_rank`.

Issue Number: N/A

## What is the new behavior?

Remove all unecessary use of `String` in favour of `&str`