### PR TITLE
refactor(yake): add terms scores and use default ordering function

### DIFF
--- a/src/common/functions.rs
+++ b/src/common/functions.rs
@@ -54,7 +54,7 @@ fn parallel_sort<'a>(map: &'a HashMap<String, f32, RandomState>) -> Vec<(&'a Str
     map_values
 }
 
-fn sort_ranked_map(map: &HashMap<String, f32, RandomState>) -> Vec<(&String, &f32)> {
+pub fn sort_ranked_map(map: &HashMap<String, f32, RandomState>) -> Vec<(&String, &f32)> {
     #[cfg(feature = "parallel")]
     {
         parallel_sort(map)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,6 +91,12 @@ fn is_percent_in_hashset(vector: &[String], hashset: &HashSet<String>, percent: 
     percentage >= percent
 }
 
+fn contains_all(strings: &[String], substrings: &[&str]) -> bool {
+    substrings
+        .iter()
+        .all(|substr| strings.contains(&substr.to_string()))
+}
+
 #[test]
 fn test_tokenize() {
     let tokenizer = tokenizer::Tokenizer::new(TEXT, &get_stop_words(), None);
@@ -562,12 +568,25 @@ fn test_yake() {
         "junior rust",
         "rust programming language",
     ];
+
+    let ranked_keywords = yake.get_ranked_keywords(10);
+    let expected_terms = ranked_keywords
+        .iter()
+        .flat_map(|s| s.split_whitespace())
+        .collect::<Vec<&str>>();
+    let ranked_terms = yake.get_ranked_terms(
+        ranked_keywords
+            .iter()
+            .fold(0, |acc, s| acc + s.split_whitespace().count()),
+    );
+
     assert!(is_percent_in_hashset(
-        &yake.get_ranked_keywords(10),
+        &ranked_keywords,
         &yake_result
             .iter()
             .map(|x| x.to_string())
             .collect::<HashSet<String>>(),
         90.0
     ));
+    assert!(contains_all(&ranked_terms, &expected_terms));
 }

--- a/src/yake/candidate_selection_and_context_builder.rs
+++ b/src/yake/candidate_selection_and_context_builder.rs
@@ -22,7 +22,6 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use super::sentences_builder::Sentence;
 
-#[derive(Clone)]
 pub struct Candidate<'a> {
     pub lexical_form: Vec<&'a str>,
     pub surface_forms: Vec<Vec<&'a str>>,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
  guidelines: https://github.com/tugascript/keyword-extraction-rs/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Other... Please describe:

## What is the current behavior?

No terms map, only keywords, this adds terms scoring as well 

## What is the new behavior?

Adds missing term functions to match other models.