### PR TITLE
fix(yake): add number check to occurrence mapping

### DIFF
--- a/src/yake/candidate_selection_and_context_builder.rs
+++ b/src/yake/candidate_selection_and_context_builder.rs
@@ -49,6 +49,10 @@ fn is_punctuation(word: &str, punctuation: &HashSet<&str>) -> bool {
     word.is_empty() || ((word.graphemes(true).count() == 1) && punctuation.contains(word))
 }
 
+fn is_invalid_word(word: &str, punctuation: &HashSet<&str>, stop_words: &HashSet<&str>) -> bool {
+    is_punctuation(word, punctuation) || stop_words.contains(word) || word.parse::<f32>().is_ok()
+}
+
 pub struct CandidateSelectionAndContextBuilder;
 
 impl<'a> CandidateSelectionAndContextBuilder {
@@ -82,11 +86,10 @@ impl<'a> CandidateSelectionAndContextBuilder {
                             .iter()
                             .map(|s| s.as_str())
                             .collect::<Vec<&'a str>>();
-                        if stems.iter().any(|w| {
-                            is_punctuation(w, &punctuation)
-                                || stop_words.contains(w)
-                                || w.parse::<f32>().is_ok()
-                        }) {
+                        if stems
+                            .iter()
+                            .any(|w| is_invalid_word(&w, &punctuation, &stop_words))
+                        {
                             return;
                         }
 
@@ -119,7 +122,7 @@ impl<'a> CandidateSelectionAndContextBuilder {
                         let key1 = sentence.stemmed[j].as_str();
                         let w1_str = w1.as_ref();
 
-                        if !(is_punctuation(key1, &punctuation) || stop_words.contains(key1)) {
+                        if !is_invalid_word(key1, &punctuation, &stop_words) {
                             let entry = occurrences.entry(key1).or_default();
                             entry.push((w1_str, i));
                         }

--- a/src/yake/feature_extraction.rs
+++ b/src/yake/feature_extraction.rs
@@ -94,6 +94,7 @@ impl<'a> FeatureExtractor {
                     .get(word)
                     .map(|(v1, v2)| (v1.as_slice(), v2.as_slice()))
                     .unwrap_or((&[], &[]));
+
                 let left_context_unique = left_right_context
                     .0
                     .iter()
@@ -111,7 +112,6 @@ impl<'a> FeatureExtractor {
                     .iter()
                     .copied()
                     .collect::<HashSet<&str>>();
-
                 let wr = if !right_context_unique.is_empty() {
                     right_context_unique.len() as f32
                         / (left_right_context.1.len() as f32 + f32::EPSILON)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
  guidelines: https://github.com/tugascript/keyword-extraction-rs/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Other... Please describe:

## What is the current behavior?

Doesn't check if occurrence is numeric, and adds numbers to occurrences `HashMap`

Issue Number: N/A

## What is the new behavior?

Adds a `is_invalid_word` function to make sure all invalid terms are filtered out in every step of the `candidate_selection_and_context_builder.rs`