### PR TITLE
refactor(yake): use queue for slidding window buffer

### DIFF
--- a/src/yake/candidate_selection_and_context_builder.rs
+++ b/src/yake/candidate_selection_and_context_builder.rs
@@ -15,7 +15,7 @@
 
 use std::{
     cmp::min,
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
 };
 
 use unicode_segmentation::UnicodeSegmentation;
@@ -79,7 +79,7 @@ impl<'a> CandidateSelectionAndContextBuilder {
             ),
             |(mut candidates, mut dedup_map, mut occurrences, mut lr_contexts), (i, sentence)| {
                 sentence.words.iter().enumerate().fold(
-                    Vec::<(&str, usize)>::with_capacity(window_size + 1),
+                    VecDeque::<(&str, usize)>::with_capacity(window_size + 1),
                     |mut buffer, (j, w1)| {
                         // Candidate Selection
                         (j + 1..=min(j + ngram, sentence.length)).for_each(|k: usize| {
@@ -89,7 +89,7 @@ impl<'a> CandidateSelectionAndContextBuilder {
                                 .collect::<Vec<&'a str>>();
                             if stems
                                 .iter()
-                                .any(|w| is_invalid_word(&w, &punctuation, &stop_words))
+                                .any(|w| is_invalid_word(w, &punctuation, &stop_words))
                             {
                                 return;
                             }
@@ -134,10 +134,10 @@ impl<'a> CandidateSelectionAndContextBuilder {
                             entry_2.1.push(w1_str);
                         });
 
-                        buffer.push((w1_str, j));
+                        buffer.push_back((w1_str, j));
 
                         if buffer.len() > window_size {
-                            buffer.remove(0);
+                            buffer.pop_front();
                         }
 
                         buffer

--- a/src/yake/mod.rs
+++ b/src/yake/mod.rs
@@ -29,7 +29,7 @@ use crate::common::{get_ranked_scores, get_ranked_strings, sort_ranked_map, PUNC
 use levenshtein::Levenshtein;
 use yake_logic::YakeLogic;
 
-fn build_ranked_keywords(vec: &mut Vec<String>, word: &str, threshold: f32) -> () {
+fn build_ranked_keywords(vec: &mut Vec<String>, word: &str, threshold: f32) {
     if vec
         .iter()
         .any(|w| Levenshtein::new(w, word).ratio() >= threshold)
@@ -39,7 +39,7 @@ fn build_ranked_keywords(vec: &mut Vec<String>, word: &str, threshold: f32) -> (
     vec.push(word.to_string());
 }
 
-fn build_ranked_scores(vec: &mut Vec<(String, f32)>, word: &str, score: f32, threshold: f32) -> () {
+fn build_ranked_scores(vec: &mut Vec<(String, f32)>, word: &str, score: f32, threshold: f32) {
     if vec
         .iter()
         .any(|(w, _)| Levenshtein::new(w, word).ratio() >= threshold)

--- a/src/yake/yake_logic.rs
+++ b/src/yake/yake_logic.rs
@@ -85,7 +85,7 @@ impl YakeLogic {
             .collect::<HashMap<String, f32>>()
     }
 
-    fn score_terms<'a>(word_scores: HashMap<&'a str, f32>) -> HashMap<String, f32> {
+    fn score_terms(word_scores: HashMap<&str, f32>) -> HashMap<String, f32> {
         let word_scores_len = word_scores.len();
         let (vec_scores, max) = word_scores.into_iter().fold(
             (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
  guidelines: https://github.com/tugascript/keyword-extraction-rs/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Other... Please describe:

## What is the current behavior?

Uses Vec for buffer slidding window

Issue Number: N/A

## What is the new behavior?

Uses VecDeque for the buffer